### PR TITLE
Feature/standarize chi prometheus

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/go-chi/chi"
 
-	"github.com/766b/chi-prometheus"
+	"github.com/payfazz/chi-prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/middleware.go
+++ b/middleware.go
@@ -58,8 +58,8 @@ func (c Middleware) handler(next http.Handler) http.Handler {
 		start := time.Now()
 		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 		next.ServeHTTP(ww, r)
-		c.reqs.WithLabelValues(http.StatusCode(ww.Status()), r.Method, r.URL.Path).Inc()
-		c.latency.WithLabelValues(http.StatusCode(ww.Status()), r.Method, r.URL.Path).Observe(float64(time.Since(start).Nanoseconds()) / 1000000)
+		c.reqs.WithLabelValues(http.StatusText(ww.Status()), r.Method, r.URL.Path).Inc()
+		c.latency.WithLabelValues(http.StatusText(ww.Status()), r.Method, r.URL.Path).Observe(float64(time.Since(start).Nanoseconds()) / 1000000)
 	}
 	return http.HandlerFunc(fn)
 }

--- a/middleware.go
+++ b/middleware.go
@@ -14,72 +14,72 @@ var (
 )
 
 var statusText = map[int]string{
-	StatusContinue           = 100 // RFC 7231, 6.2.1
-	StatusSwitchingProtocols = 101 // RFC 7231, 6.2.2
-	StatusProcessing         = 102 // RFC 2518, 10.1
-	StatusEarlyHints         = 103 // RFC 8297
+	StatusContinue:           "100", // RFC 7231, 6.2.1
+	StatusSwitchingProtocols: "101", // RFC 7231, 6.2.2
+	StatusProcessing:         "102", // RFC 2518, 10.1
+	StatusEarlyHints:         "103", // RFC 8297
 
-	StatusOK                   = 200 // RFC 7231, 6.3.1
-	StatusCreated              = 201 // RFC 7231, 6.3.2
-	StatusAccepted             = 202 // RFC 7231, 6.3.3
-	StatusNonAuthoritativeInfo = 203 // RFC 7231, 6.3.4
-	StatusNoContent            = 204 // RFC 7231, 6.3.5
-	StatusResetContent         = 205 // RFC 7231, 6.3.6
-	StatusPartialContent       = 206 // RFC 7233, 4.1
-	StatusMultiStatus          = 207 // RFC 4918, 11.1
-	StatusAlreadyReported      = 208 // RFC 5842, 7.1
-	StatusIMUsed               = 226 // RFC 3229, 10.4.1
+	StatusOK:                   "200", // RFC 7231, 6.3.1
+	StatusCreated:              "201", // RFC 7231, 6.3.2
+	StatusAccepted:             "202", // RFC 7231, 6.3.3
+	StatusNonAuthoritativeInfo: "203", // RFC 7231, 6.3.4
+	StatusNoContent:            "204", // RFC 7231, 6.3.5
+	StatusResetContent:         "205", // RFC 7231, 6.3.6
+	StatusPartialContent:       "206", // RFC 7233, 4.1
+	StatusMultiStatus:          "207", // RFC 4918, 11.1
+	StatusAlreadyReported:      "208", // RFC 5842, 7.1
+	StatusIMUsed:               "226", // RFC 3229, 10.4.1
 
-	StatusMultipleChoices   = 300 // RFC 7231, 6.4.1
-	StatusMovedPermanently  = 301 // RFC 7231, 6.4.2
-	StatusFound             = 302 // RFC 7231, 6.4.3
-	StatusSeeOther          = 303 // RFC 7231, 6.4.4
-	StatusNotModified       = 304 // RFC 7232, 4.1
-	StatusUseProxy          = 305 // RFC 7231, 6.4.5
-	StatusTemporaryRedirect = 307 // RFC 7231, 6.4.7
-	StatusPermanentRedirect = 308 // RFC 7538, 3
+	StatusMultipleChoices:   "300", // RFC 7231, 6.4.1
+	StatusMovedPermanently:  "301", // RFC 7231, 6.4.2
+	StatusFound:             "302", // RFC 7231, 6.4.3
+	StatusSeeOther:          "303", // RFC 7231, 6.4.4
+	StatusNotModified:       "304", // RFC 7232, 4.1
+	StatusUseProxy:          "305", // RFC 7231, 6.4.5
+	StatusTemporaryRedirect: "307", // RFC 7231, 6.4.7
+	StatusPermanentRedirect: "308", // RFC 7538, 3
 
-	StatusBadRequest                   = 400 // RFC 7231, 6.5.1
-	StatusUnauthorized                 = 401 // RFC 7235, 3.1
-	StatusPaymentRequired              = 402 // RFC 7231, 6.5.2
-	StatusForbidden                    = 403 // RFC 7231, 6.5.3
-	StatusNotFound                     = 404 // RFC 7231, 6.5.4
-	StatusMethodNotAllowed             = 405 // RFC 7231, 6.5.5
-	StatusNotAcceptable                = 406 // RFC 7231, 6.5.6
-	StatusProxyAuthRequired            = 407 // RFC 7235, 3.2
-	StatusRequestTimeout               = 408 // RFC 7231, 6.5.7
-	StatusConflict                     = 409 // RFC 7231, 6.5.8
-	StatusGone                         = 410 // RFC 7231, 6.5.9
-	StatusLengthRequired               = 411 // RFC 7231, 6.5.10
-	StatusPreconditionFailed           = 412 // RFC 7232, 4.2
-	StatusRequestEntityTooLarge        = 413 // RFC 7231, 6.5.11
-	StatusRequestURITooLong            = 414 // RFC 7231, 6.5.12
-	StatusUnsupportedMediaType         = 415 // RFC 7231, 6.5.13
-	StatusRequestedRangeNotSatisfiable = 416 // RFC 7233, 4.4
-	StatusExpectationFailed            = 417 // RFC 7231, 6.5.14
-	StatusTeapot                       = 418 // RFC 7168, 2.3.3
-	StatusMisdirectedRequest           = 421 // RFC 7540, 9.1.2
-	StatusUnprocessableEntity          = 422 // RFC 4918, 11.2
-	StatusLocked                       = 423 // RFC 4918, 11.3
-	StatusFailedDependency             = 424 // RFC 4918, 11.4
-	StatusTooEarly                     = 425 // RFC 8470, 5.2.
-	StatusUpgradeRequired              = 426 // RFC 7231, 6.5.15
-	StatusPreconditionRequired         = 428 // RFC 6585, 3
-	StatusTooManyRequests              = 429 // RFC 6585, 4
-	StatusRequestHeaderFieldsTooLarge  = 431 // RFC 6585, 5
-	StatusUnavailableForLegalReasons   = 451 // RFC 7725, 3
+	StatusBadRequest:                   "400", // RFC 7231, 6.5.1
+	StatusUnauthorized:                 "401", // RFC 7235, 3.1
+	StatusPaymentRequired:              "402", // RFC 7231, 6.5.2
+	StatusForbidden:                    "403", // RFC 7231, 6.5.3
+	StatusNotFound:                     "404", // RFC 7231, 6.5.4
+	StatusMethodNotAllowed:             "405", // RFC 7231, 6.5.5
+	StatusNotAcceptable:                "406", // RFC 7231, 6.5.6
+	StatusProxyAuthRequired:            "407", // RFC 7235, 3.2
+	StatusRequestTimeout:               "408", // RFC 7231, 6.5.7
+	StatusConflict:                     "409", // RFC 7231, 6.5.8
+	StatusGone:                         "410", // RFC 7231, 6.5.9
+	StatusLengthRequired:               "411", // RFC 7231, 6.5.10
+	StatusPreconditionFailed:           "412", // RFC 7232, 4.2
+	StatusRequestEntityTooLarge:        "413", // RFC 7231, 6.5.11
+	StatusRequestURITooLong:            "414", // RFC 7231, 6.5.12
+	StatusUnsupportedMediaType:         "415", // RFC 7231, 6.5.13
+	StatusRequestedRangeNotSatisfiable: "416", // RFC 7233, 4.4
+	StatusExpectationFailed:            "417", // RFC 7231, 6.5.14
+	StatusTeapot:                       "418", // RFC 7168, 2.3.3
+	StatusMisdirectedRequest:           "421", // RFC 7540, 9.1.2
+	StatusUnprocessableEntity:          "422", // RFC 4918, 11.2
+	StatusLocked:                       "423", // RFC 4918, 11.3
+	StatusFailedDependency:             "424", // RFC 4918, 11.4
+	StatusTooEarly:                     "425", // RFC 8470, 5.2.
+	StatusUpgradeRequired:              "426", // RFC 7231, 6.5.15
+	StatusPreconditionRequired:         "428", // RFC 6585, 3
+	StatusTooManyRequests:              "429", // RFC 6585, 4
+	StatusRequestHeaderFieldsTooLarge:  "431", // RFC 6585, 5
+	StatusUnavailableForLegalReasons:   "451", // RFC 7725, 3
 
-	StatusInternalServerError           = 500 // RFC 7231, 6.6.1
-	StatusNotImplemented                = 501 // RFC 7231, 6.6.2
-	StatusBadGateway                    = 502 // RFC 7231, 6.6.3
-	StatusServiceUnavailable            = 503 // RFC 7231, 6.6.4
-	StatusGatewayTimeout                = 504 // RFC 7231, 6.6.5
-	StatusHTTPVersionNotSupported       = 505 // RFC 7231, 6.6.6
-	StatusVariantAlsoNegotiates         = 506 // RFC 2295, 8.1
-	StatusInsufficientStorage           = 507 // RFC 4918, 11.5
-	StatusLoopDetected                  = 508 // RFC 5842, 7.2
-	StatusNotExtended                   = 510 // RFC 2774, 7
-	StatusNetworkAuthenticationRequired = 511 // RFC 6585, 6
+	StatusInternalServerError:           "500", // RFC 7231, 6.6.1
+	StatusNotImplemented:                "501", // RFC 7231, 6.6.2
+	StatusBadGateway:                    "502", // RFC 7231, 6.6.3
+	StatusServiceUnavailable:            "503", // RFC 7231, 6.6.4
+	StatusGatewayTimeout:                "504", // RFC 7231, 6.6.5
+	StatusHTTPVersionNotSupported:       "505", // RFC 7231, 6.6.6
+	StatusVariantAlsoNegotiates:         "506", // RFC 2295, 8.1
+	StatusInsufficientStorage:           "507", // RFC 4918, 11.5
+	StatusLoopDetected:                  "508", // RFC 5842, 7.2
+	StatusNotExtended:                   "510", // RFC 2774, 7
+	StatusNetworkAuthenticationRequired: "511", // RFC 6585, 6
 }
 
 const (

--- a/middleware.go
+++ b/middleware.go
@@ -3,6 +3,7 @@ package chiprometheus
 
 import (
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/go-chi/chi/middleware"
@@ -58,8 +59,8 @@ func (c Middleware) handler(next http.Handler) http.Handler {
 		start := time.Now()
 		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 		next.ServeHTTP(ww, r)
-		c.reqs.WithLabelValues(ww.Status(), r.Method, r.URL.Path).Inc()
-		c.latency.WithLabelValues(ww.Status(), r.Method, r.URL.Path).Observe(float64(time.Since(start).Nanoseconds()) / 1000000)
+		c.reqs.WithLabelValues(strconv.Itoa(ww.Status()), r.Method, r.URL.Path).Inc()
+		c.latency.WithLabelValues(strconv.Itoa(ww.Status()), r.Method, r.URL.Path).Observe(float64(time.Since(start).Nanoseconds()) / 1000000)
 	}
 	return http.HandlerFunc(fn)
 }

--- a/middleware.go
+++ b/middleware.go
@@ -13,6 +13,75 @@ var (
 	dflBuckets = []float64{300, 1200, 5000, 7000, 10000}
 )
 
+var statusText = map[int]string{
+	StatusContinue           = 100 // RFC 7231, 6.2.1
+	StatusSwitchingProtocols = 101 // RFC 7231, 6.2.2
+	StatusProcessing         = 102 // RFC 2518, 10.1
+	StatusEarlyHints         = 103 // RFC 8297
+
+	StatusOK                   = 200 // RFC 7231, 6.3.1
+	StatusCreated              = 201 // RFC 7231, 6.3.2
+	StatusAccepted             = 202 // RFC 7231, 6.3.3
+	StatusNonAuthoritativeInfo = 203 // RFC 7231, 6.3.4
+	StatusNoContent            = 204 // RFC 7231, 6.3.5
+	StatusResetContent         = 205 // RFC 7231, 6.3.6
+	StatusPartialContent       = 206 // RFC 7233, 4.1
+	StatusMultiStatus          = 207 // RFC 4918, 11.1
+	StatusAlreadyReported      = 208 // RFC 5842, 7.1
+	StatusIMUsed               = 226 // RFC 3229, 10.4.1
+
+	StatusMultipleChoices   = 300 // RFC 7231, 6.4.1
+	StatusMovedPermanently  = 301 // RFC 7231, 6.4.2
+	StatusFound             = 302 // RFC 7231, 6.4.3
+	StatusSeeOther          = 303 // RFC 7231, 6.4.4
+	StatusNotModified       = 304 // RFC 7232, 4.1
+	StatusUseProxy          = 305 // RFC 7231, 6.4.5
+	StatusTemporaryRedirect = 307 // RFC 7231, 6.4.7
+	StatusPermanentRedirect = 308 // RFC 7538, 3
+
+	StatusBadRequest                   = 400 // RFC 7231, 6.5.1
+	StatusUnauthorized                 = 401 // RFC 7235, 3.1
+	StatusPaymentRequired              = 402 // RFC 7231, 6.5.2
+	StatusForbidden                    = 403 // RFC 7231, 6.5.3
+	StatusNotFound                     = 404 // RFC 7231, 6.5.4
+	StatusMethodNotAllowed             = 405 // RFC 7231, 6.5.5
+	StatusNotAcceptable                = 406 // RFC 7231, 6.5.6
+	StatusProxyAuthRequired            = 407 // RFC 7235, 3.2
+	StatusRequestTimeout               = 408 // RFC 7231, 6.5.7
+	StatusConflict                     = 409 // RFC 7231, 6.5.8
+	StatusGone                         = 410 // RFC 7231, 6.5.9
+	StatusLengthRequired               = 411 // RFC 7231, 6.5.10
+	StatusPreconditionFailed           = 412 // RFC 7232, 4.2
+	StatusRequestEntityTooLarge        = 413 // RFC 7231, 6.5.11
+	StatusRequestURITooLong            = 414 // RFC 7231, 6.5.12
+	StatusUnsupportedMediaType         = 415 // RFC 7231, 6.5.13
+	StatusRequestedRangeNotSatisfiable = 416 // RFC 7233, 4.4
+	StatusExpectationFailed            = 417 // RFC 7231, 6.5.14
+	StatusTeapot                       = 418 // RFC 7168, 2.3.3
+	StatusMisdirectedRequest           = 421 // RFC 7540, 9.1.2
+	StatusUnprocessableEntity          = 422 // RFC 4918, 11.2
+	StatusLocked                       = 423 // RFC 4918, 11.3
+	StatusFailedDependency             = 424 // RFC 4918, 11.4
+	StatusTooEarly                     = 425 // RFC 8470, 5.2.
+	StatusUpgradeRequired              = 426 // RFC 7231, 6.5.15
+	StatusPreconditionRequired         = 428 // RFC 6585, 3
+	StatusTooManyRequests              = 429 // RFC 6585, 4
+	StatusRequestHeaderFieldsTooLarge  = 431 // RFC 6585, 5
+	StatusUnavailableForLegalReasons   = 451 // RFC 7725, 3
+
+	StatusInternalServerError           = 500 // RFC 7231, 6.6.1
+	StatusNotImplemented                = 501 // RFC 7231, 6.6.2
+	StatusBadGateway                    = 502 // RFC 7231, 6.6.3
+	StatusServiceUnavailable            = 503 // RFC 7231, 6.6.4
+	StatusGatewayTimeout                = 504 // RFC 7231, 6.6.5
+	StatusHTTPVersionNotSupported       = 505 // RFC 7231, 6.6.6
+	StatusVariantAlsoNegotiates         = 506 // RFC 2295, 8.1
+	StatusInsufficientStorage           = 507 // RFC 4918, 11.5
+	StatusLoopDetected                  = 508 // RFC 5842, 7.2
+	StatusNotExtended                   = 510 // RFC 2774, 7
+	StatusNetworkAuthenticationRequired = 511 // RFC 6585, 6
+}
+
 const (
 	reqsName    = "http_requests_total"
 	latencyName = "http_request_duration_milliseconds"
@@ -58,8 +127,12 @@ func (c Middleware) handler(next http.Handler) http.Handler {
 		start := time.Now()
 		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 		next.ServeHTTP(ww, r)
-		c.reqs.WithLabelValues(http.StatusText(ww.StatusCode()), r.Method, r.URL.Path).Inc()
-		c.latency.WithLabelValues(http.StatusText(ww.StatusCode()), r.Method, r.URL.Path).Observe(float64(time.Since(start).Nanoseconds()) / 1000000)
+		c.reqs.WithLabelValues(statusCode(ww.Status()), r.Method, r.URL.Path).Inc()
+		c.latency.WithLabelValues(statusCode(ww.Status()), r.Method, r.URL.Path).Observe(float64(time.Since(start).Nanoseconds()) / 1000000)
 	}
 	return http.HandlerFunc(fn)
+}
+
+func statusCode(code int) string {
+	return statusText[code]
 }

--- a/middleware.go
+++ b/middleware.go
@@ -13,75 +13,6 @@ var (
 	dflBuckets = []float64{300, 1200, 5000, 7000, 10000}
 )
 
-var statusText = map[int]string{
-	StatusContinue:           "100", // RFC 7231, 6.2.1
-	StatusSwitchingProtocols: "101", // RFC 7231, 6.2.2
-	StatusProcessing:         "102", // RFC 2518, 10.1
-	StatusEarlyHints:         "103", // RFC 8297
-
-	StatusOK:                   "200", // RFC 7231, 6.3.1
-	StatusCreated:              "201", // RFC 7231, 6.3.2
-	StatusAccepted:             "202", // RFC 7231, 6.3.3
-	StatusNonAuthoritativeInfo: "203", // RFC 7231, 6.3.4
-	StatusNoContent:            "204", // RFC 7231, 6.3.5
-	StatusResetContent:         "205", // RFC 7231, 6.3.6
-	StatusPartialContent:       "206", // RFC 7233, 4.1
-	StatusMultiStatus:          "207", // RFC 4918, 11.1
-	StatusAlreadyReported:      "208", // RFC 5842, 7.1
-	StatusIMUsed:               "226", // RFC 3229, 10.4.1
-
-	StatusMultipleChoices:   "300", // RFC 7231, 6.4.1
-	StatusMovedPermanently:  "301", // RFC 7231, 6.4.2
-	StatusFound:             "302", // RFC 7231, 6.4.3
-	StatusSeeOther:          "303", // RFC 7231, 6.4.4
-	StatusNotModified:       "304", // RFC 7232, 4.1
-	StatusUseProxy:          "305", // RFC 7231, 6.4.5
-	StatusTemporaryRedirect: "307", // RFC 7231, 6.4.7
-	StatusPermanentRedirect: "308", // RFC 7538, 3
-
-	StatusBadRequest:                   "400", // RFC 7231, 6.5.1
-	StatusUnauthorized:                 "401", // RFC 7235, 3.1
-	StatusPaymentRequired:              "402", // RFC 7231, 6.5.2
-	StatusForbidden:                    "403", // RFC 7231, 6.5.3
-	StatusNotFound:                     "404", // RFC 7231, 6.5.4
-	StatusMethodNotAllowed:             "405", // RFC 7231, 6.5.5
-	StatusNotAcceptable:                "406", // RFC 7231, 6.5.6
-	StatusProxyAuthRequired:            "407", // RFC 7235, 3.2
-	StatusRequestTimeout:               "408", // RFC 7231, 6.5.7
-	StatusConflict:                     "409", // RFC 7231, 6.5.8
-	StatusGone:                         "410", // RFC 7231, 6.5.9
-	StatusLengthRequired:               "411", // RFC 7231, 6.5.10
-	StatusPreconditionFailed:           "412", // RFC 7232, 4.2
-	StatusRequestEntityTooLarge:        "413", // RFC 7231, 6.5.11
-	StatusRequestURITooLong:            "414", // RFC 7231, 6.5.12
-	StatusUnsupportedMediaType:         "415", // RFC 7231, 6.5.13
-	StatusRequestedRangeNotSatisfiable: "416", // RFC 7233, 4.4
-	StatusExpectationFailed:            "417", // RFC 7231, 6.5.14
-	StatusTeapot:                       "418", // RFC 7168, 2.3.3
-	StatusMisdirectedRequest:           "421", // RFC 7540, 9.1.2
-	StatusUnprocessableEntity:          "422", // RFC 4918, 11.2
-	StatusLocked:                       "423", // RFC 4918, 11.3
-	StatusFailedDependency:             "424", // RFC 4918, 11.4
-	StatusTooEarly:                     "425", // RFC 8470, 5.2.
-	StatusUpgradeRequired:              "426", // RFC 7231, 6.5.15
-	StatusPreconditionRequired:         "428", // RFC 6585, 3
-	StatusTooManyRequests:              "429", // RFC 6585, 4
-	StatusRequestHeaderFieldsTooLarge:  "431", // RFC 6585, 5
-	StatusUnavailableForLegalReasons:   "451", // RFC 7725, 3
-
-	StatusInternalServerError:           "500", // RFC 7231, 6.6.1
-	StatusNotImplemented:                "501", // RFC 7231, 6.6.2
-	StatusBadGateway:                    "502", // RFC 7231, 6.6.3
-	StatusServiceUnavailable:            "503", // RFC 7231, 6.6.4
-	StatusGatewayTimeout:                "504", // RFC 7231, 6.6.5
-	StatusHTTPVersionNotSupported:       "505", // RFC 7231, 6.6.6
-	StatusVariantAlsoNegotiates:         "506", // RFC 2295, 8.1
-	StatusInsufficientStorage:           "507", // RFC 4918, 11.5
-	StatusLoopDetected:                  "508", // RFC 5842, 7.2
-	StatusNotExtended:                   "510", // RFC 2774, 7
-	StatusNetworkAuthenticationRequired: "511", // RFC 6585, 6
-}
-
 const (
 	reqsName    = "http_requests_total"
 	latencyName = "http_request_duration_milliseconds"
@@ -127,12 +58,8 @@ func (c Middleware) handler(next http.Handler) http.Handler {
 		start := time.Now()
 		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 		next.ServeHTTP(ww, r)
-		c.reqs.WithLabelValues(statusCode(ww.Status()), r.Method, r.URL.Path).Inc()
-		c.latency.WithLabelValues(statusCode(ww.Status()), r.Method, r.URL.Path).Observe(float64(time.Since(start).Nanoseconds()) / 1000000)
+		c.reqs.WithLabelValues(ww.Status(), r.Method, r.URL.Path).Inc()
+		c.latency.WithLabelValues(ww.Status(), r.Method, r.URL.Path).Observe(float64(time.Since(start).Nanoseconds()) / 1000000)
 	}
 	return http.HandlerFunc(fn)
-}
-
-func statusCode(code int) string {
-	return statusText[code]
 }

--- a/middleware.go
+++ b/middleware.go
@@ -10,12 +10,12 @@ import (
 )
 
 var (
-	dflBuckets = []float64{300, 1200, 5000}
+	dflBuckets = []float64{300, 1200, 5000, 7000, 10000}
 )
 
 const (
-	reqsName    = "chi_requests_total"
-	latencyName = "chi_request_duration_milliseconds"
+	reqsName    = "http_requests_total"
+	latencyName = "http_request_duration_milliseconds"
 )
 
 // Middleware is a handler that exposes prometheus metrics for the number of requests,
@@ -58,8 +58,8 @@ func (c Middleware) handler(next http.Handler) http.Handler {
 		start := time.Now()
 		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 		next.ServeHTTP(ww, r)
-		c.reqs.WithLabelValues(http.StatusText(ww.Status()), r.Method, r.URL.Path).Inc()
-		c.latency.WithLabelValues(http.StatusText(ww.Status()), r.Method, r.URL.Path).Observe(float64(time.Since(start).Nanoseconds()) / 1000000)
+		c.reqs.WithLabelValues(http.StatusCode(ww.Status()), r.Method, r.URL.Path).Inc()
+		c.latency.WithLabelValues(http.StatusCode(ww.Status()), r.Method, r.URL.Path).Observe(float64(time.Since(start).Nanoseconds()) / 1000000)
 	}
 	return http.HandlerFunc(fn)
 }

--- a/middleware.go
+++ b/middleware.go
@@ -58,8 +58,8 @@ func (c Middleware) handler(next http.Handler) http.Handler {
 		start := time.Now()
 		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 		next.ServeHTTP(ww, r)
-		c.reqs.WithLabelValues(http.StatusText(ww.Status()), r.Method, r.URL.Path).Inc()
-		c.latency.WithLabelValues(http.StatusText(ww.Status()), r.Method, r.URL.Path).Observe(float64(time.Since(start).Nanoseconds()) / 1000000)
+		c.reqs.WithLabelValues(http.StatusText(ww.StatusCode()), r.Method, r.URL.Path).Inc()
+		c.latency.WithLabelValues(http.StatusText(ww.StatusCode()), r.Method, r.URL.Path).Observe(float64(time.Since(start).Nanoseconds()) / 1000000)
 	}
 	return http.HandlerFunc(fn)
 }


### PR DESCRIPTION
# HELP http_request_duration_milliseconds How long it took to process the request, partitioned by status code, method and HTTP path.
# TYPE http_request_duration_milliseconds histogram
http_request_duration_milliseconds_bucket{code="200",method="POST",path="/v3/login",service="post-api",le="300"} 1
http_request_duration_milliseconds_bucket{code="200",method="POST",path="/v3/login",service="post-api",le="1200"} 1
http_request_duration_milliseconds_bucket{code="200",method="POST",path="/v3/login",service="post-api",le="5000"} 1
http_request_duration_milliseconds_bucket{code="200",method="POST",path="/v3/login",service="post-api",le="7000"} 1
http_request_duration_milliseconds_bucket{code="200",method="POST",path="/v3/login",service="post-api",le="10000"} 1
http_request_duration_milliseconds_bucket{code="200",method="POST",path="/v3/login",service="post-api",le="+Inf"} 1
http_request_duration_milliseconds_sum{code="200",method="POST",path="/v3/login",service="post-api"} 106.68513
http_request_duration_milliseconds_count{code="200",method="POST",path="/v3/login",service="post-api"} 1
http_request_duration_milliseconds_bucket{code="401",method="GET",path="/v2/reports/expenses",service="post-api",le="300"} 1
http_request_duration_milliseconds_bucket{code="401",method="GET",path="/v2/reports/expenses",service="post-api",le="1200"} 1
http_request_duration_milliseconds_bucket{code="401",method="GET",path="/v2/reports/expenses",service="post-api",le="5000"} 1
http_request_duration_milliseconds_bucket{code="401",method="GET",path="/v2/reports/expenses",service="post-api",le="7000"} 1
http_request_duration_milliseconds_bucket{code="401",method="GET",path="/v2/reports/expenses",service="post-api",le="10000"} 1
http_request_duration_milliseconds_bucket{code="401",method="GET",path="/v2/reports/expenses",service="post-api",le="+Inf"} 1
http_request_duration_milliseconds_sum{code="401",method="GET",path="/v2/reports/expenses",service="post-api"} 8.228264
http_request_duration_milliseconds_count{code="401",method="GET",path="/v2/reports/expenses",service="post-api"} 1
# HELP http_requests_total How many HTTP requests processed, partitioned by status code, method and HTTP path.
# TYPE http_requests_total counter
http_requests_total{code="200",method="POST",path="/v3/login",service="post-api"} 1
http_requests_total{code="401",method="GET",path="/v2/reports/expenses",service="post-api"} 1